### PR TITLE
Diversify administrative court classes

### DIFF
--- a/juris-at.csl
+++ b/juris-at.csl
@@ -16,14 +16,16 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Juris-M style module for Austria.</summary>
-    <updated>2020-12-20T22:08:13+01:00</updated>
+    <updated>2021-04-07T16:37:49+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <law-module types="legal_case bill legislation regulation"/>
   </info>
   <locale xmlns="http://purl.org/net/xbiblio/csl" xml:lang="de">
     <court-class name="v0" country="at" courts="vfgh"/>
     <court-class name="v1" country="at" courts="vwgh"/>
-    <court-class name="v2" country="at" courts="bvwg bfg lvwg vgw asylgh"/>
+    <court-class name="v2f" country="at" courts="bfg ufs"/>
+    <court-class name="v2" country="at" courts="bvwg bfg lvwg vgw asylgh ufs uvs ubas"/>
+    <court-class name="v3" country="at" courts="dsk dsb bvga opms bwb"/>
     <court-class name="o1" country="at" courts="ogh"/>
     <court-class name="o2" country="at" courts="olg"/>
     <court-class name="o3" country="at" courts="lg lgs lgzrs asg hg"/>

--- a/juris-eu.int+cjeu-deAT.csl
+++ b/juris-eu.int+cjeu-deAT.csl
@@ -16,7 +16,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Juris-M style module for European Union ECLI standard</summary>
-    <updated>2020-12-10T14:31:02+01:00</updated>
+    <updated>2021-04-07T22:36:27+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <law-module types="legal_case"/>
   </info>
@@ -73,8 +73,7 @@
               <condition variable="author"/>
               <condition variable="genre" match="none"/>
             </conditions>
-            <!-- Schlussantraege -->
-            <text value="SA"/>
+            <text value="GA"/>
             <names variable="author" font-style="italic"/>
             <number variable="division"/>
           </else-if>


### PR DESCRIPTION
- Add a special class 'v2f' for financial/tax courts which is a subset
of 'v2', enabling special sorting for tax law styles.
- Add a class 'v3' for court-like administrative bodies.